### PR TITLE
feat: rewrite the whole login flow around nodriver

### DIFF
--- a/.github/workflows/push_build.yml
+++ b/.github/workflows/push_build.yml
@@ -28,6 +28,11 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
+    - name: Fix-up encoding for nodriver network.py
+      run: |
+        export NODRIVER_LOC="$(python -c "import site; print(site.getsitepackages()[-1] + '/nodriver/cdp/network.py')")"
+        iconv -f ISO-8859-15 -t UTF-8 "$NODRIVER_LOC" > /tmp/network-fix.py
+        mv /tmp/network-fix.py "$NODRIVER_LOC"
     - name: Build Package
       run: make all
     - name: Prepare Package for Upload
@@ -59,6 +64,11 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
+    - name: Fix-up encoding for nodriver network.py
+      run: |
+        export NODRIVER_LOC="$(python -c "import site; print(site.getsitepackages()[-1] + '/nodriver/cdp/network.py')")"
+        iconv -f ISO-8859-15 -t UTF-8 "$NODRIVER_LOC" > /tmp/network-fix.py
+        mv /tmp/network-fix.py "$NODRIVER_LOC"
     - name: Build Package
       run: make all
     - name: Prepare Package for Upload
@@ -86,6 +96,11 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+      - name: Fix-up encoding for nodriver network.py
+        run: |
+          export NODRIVER_LOC="$(python -c "import site; print(site.getsitepackages()[-1] + '/nodriver/cdp/network.py')")"
+          iconv -f ISO-8859-15 -t UTF-8 "$NODRIVER_LOC" > /tmp/network-fix.py
+          mv /tmp/network-fix.py "$NODRIVER_LOC"
       - name: Build Package
         run: ARCH_FLAGS=--macos-target-arch=x86_64 make all
       - name: Prepare Package for Upload
@@ -113,6 +128,11 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+      - name: Fix-up encoding for nodriver network.py
+        run: |
+          export NODRIVER_LOC="$(python -c "import site; print(site.getsitepackages()[-1] + '/nodriver/cdp/network.py')")"
+          iconv -f ISO-8859-15 -t UTF-8 "$NODRIVER_LOC" > /tmp/network-fix.py
+          mv /tmp/network-fix.py "$NODRIVER_LOC"
       - name: Build Package
         run: ARCH_FLAGS=--macos-target-arch=arm64 make all
       - name: Prepare Package for Upload

--- a/JustEatLinker.py
+++ b/JustEatLinker.py
@@ -25,8 +25,8 @@ import traceback
 import webbrowser
 import json
 import nodriver
+import requests
 
-from curl_cffi import requests
 from constants import file_path, linker_version
 from oauth import WiiLinkAccountPage, WiiNumberSelector
 from just_eat import JustEatCredentialsPage, CountrySelect

--- a/JustEatLinker.py
+++ b/JustEatLinker.py
@@ -17,18 +17,19 @@
 # nuitka-project: --include-data-dir={MAIN_DIRECTORY}/assets=assets
 # nuitka-project: --include-data-file={MAIN_DIRECTORY}/style.qss=style.qss
 # nuitka-project: --include-data-file={MAIN_DIRECTORY}/translations/languages.json=translations/languages.json
-
+import os
 import sys
 import datetime
 import random
 import traceback
 import webbrowser
 import json
+import nodriver
 
 from curl_cffi import requests
 from constants import file_path, linker_version
 from oauth import WiiLinkAccountPage, WiiNumberSelector
-from just_eat import JustEatCredentialsPage, CountrySelect, JustEat2FAPage
+from just_eat import JustEatCredentialsPage, CountrySelect
 from PySide6.QtCore import Qt, QTimer, QLocale, QLibraryInfo, QTranslator
 from PySide6.QtGui import QIcon
 from PySide6.QtWidgets import (
@@ -160,6 +161,25 @@ class JustEatLinker(QWizard):
         self.language_selector = LanguageSelector()
         self.translation_setup()
 
+        if not os.getenv("WIILINK_BROWSER_PATH"):
+            try:
+                nodriver.Config()
+            except FileNotFoundError:
+                QMessageBox.critical(
+                    self,
+                    self.tr("Browser not found"),
+                    self.tr(
+                        """To use this app, you need to have Chromium, Google Chrome, or Microsoft Edge installed.
+
+If you are on Linux, the browser also needs to be accessible on the system PATH.
+
+If you are using Linux and do not wish to install a browser as a system package, you can download and extract a browser, then pass the full path to this app with the environment variable `WIILINK_BROWSER_PATH`."""
+                    ),
+                )
+                sys.exit(1)
+        else:
+            self.setProperty("browser", os.getenv("WIILINK_BROWSER_PATH"))
+
         self.setWindowTitle(self.tr("WiiLink Just Eat Linker"))
         self.setWizardStyle(QWizard.WizardStyle.ModernStyle)
         self.setSubTitleFormat(Qt.TextFormat.RichText)
@@ -176,8 +196,7 @@ class JustEatLinker(QWizard):
         self.setPage(2, WiiNumberSelector())
         self.setPage(3, CountrySelect())
         self.setPage(4, JustEatCredentialsPage())
-        self.setPage(5, JustEat2FAPage())
-        self.setPage(6, FinalPage())
+        self.setPage(5, FinalPage())
 
         self.setStartId(0)
 

--- a/build.ps1
+++ b/build.ps1
@@ -5,6 +5,12 @@ param(
 )
 
 $buildProject = {
+    Write-Host "Fixing nodriver network.py encoding..."
+    $NODRIVER_LOC = Invoke-Expression "python -c `"import site; print(site.getsitepackages()[-1] + '/nodriver/cdp/network.py')`""
+    Get-Content "$NODRIVER_LOC" | Set-Content -Encoding utf8 ".\network-fix.py"
+    Copy-Item -Path ".\network-fix.py" -Destination "$NODRIVER_LOC" -Force
+    Remove-Item -Path ".\network-fix.py"
+    
     Write-Host "Building Just Eat Linker..."
     pyside6-project build pyproject.toml
 

--- a/just_eat.py
+++ b/just_eat.py
@@ -105,7 +105,7 @@ IMPORTANT - DO NOT RESIZE THE BROWSER WINDOW. DOING SO CAN CAUSE THE PROCESS TO 
         self.browser_worker = BrowserWorker()
 
     def initializePage(self):
-        QTimer.singleShot(0, self.disable_next_button)
+        QTimer.singleShot(0, self.disable_back_button)
 
         try:
             resp = requests.get(
@@ -120,8 +120,8 @@ IMPORTANT - DO NOT RESIZE THE BROWSER WINDOW. DOING SO CAN CAUSE THE PROCESS TO 
                 "WiiLink Just Eat Linker - Error",
                 f"""The linker was unable to get login information from WiiLink servers.
 
-        Received status code {resp.status_code}.
-        Response: {resp.text}""",
+Received status code {resp.status_code}.
+Response: {resp.text}""",
             )
             return
         except:
@@ -132,7 +132,7 @@ IMPORTANT - DO NOT RESIZE THE BROWSER WINDOW. DOING SO CAN CAUSE THE PROCESS TO 
                 "WiiLink Just Eat Linker - Error",
                 f"""The linker was unable to get login information from WiiLink servers.
 
-        {exception_traceback}""",
+{exception_traceback}""",
             )
             return
 
@@ -177,8 +177,8 @@ IMPORTANT - DO NOT RESIZE THE BROWSER WINDOW. DOING SO CAN CAUSE THE PROCESS TO 
                 "WiiLink Just Eat Linker - Error",
                 f"""The linker was unable to link your Just Eat account to your WiiLink account.
 
-            Received status code {resp.status_code}.
-            Response: {resp.text}""",
+Received status code {resp.status_code}.
+Response: {resp.text}""",
             )
             return
         except:
@@ -189,7 +189,7 @@ IMPORTANT - DO NOT RESIZE THE BROWSER WINDOW. DOING SO CAN CAUSE THE PROCESS TO 
                 "WiiLink Just Eat Linker - Error",
                 f"""The linker was unable to link your Just Eat account to your WiiLink account.
 
-            {exception_traceback}""",
+{exception_traceback}""",
             )
             return
 
@@ -197,8 +197,8 @@ IMPORTANT - DO NOT RESIZE THE BROWSER WINDOW. DOING SO CAN CAUSE THE PROCESS TO 
         self.completeChanged.emit()
         QTimer.singleShot(0, self.wizard().next)
 
-    def disable_next_button(self):
-        self.wizard().button(QWizard.WizardButton.NextButton).setEnabled(False)
+    def disable_back_button(self):
+        self.wizard().button(QWizard.WizardButton.BackButton).setEnabled(False)
 
     def isComplete(self):
         return self.login_complete

--- a/just_eat.py
+++ b/just_eat.py
@@ -1,18 +1,17 @@
+import asyncio
 import traceback
 import uuid
+import nodriver as uc
 
 from PySide6.QtWidgets import (
     QWizardPage,
     QLabel,
     QVBoxLayout,
     QWizard,
-    QLineEdit,
-    QPushButton,
     QComboBox,
     QMessageBox,
 )
-from PySide6.QtCore import QTimer, Qt
-from PySide6.QtGui import QFont
+from PySide6.QtCore import QTimer, QObject, Signal, QThread
 from curl_cffi import requests
 from curl_cffi.requests.exceptions import HTTPError
 from constants import devices, linker_version
@@ -79,7 +78,7 @@ def link_to_server(data, wii_number, auth, device_id, acr):
 
 
 class JustEatCredentialsPage(QWizardPage):
-    has_2fa = False
+    login_complete = False
 
     # noinspection PyPackageRequirements
     def __init__(self, parent=None):
@@ -87,131 +86,30 @@ class JustEatCredentialsPage(QWizardPage):
         self.setTitle(self.tr("Just Eat Login"))
         self.setSubTitle(self.tr("Enter your credentials for your Just Eat Account."))
 
-        self.username_label = QLabel(self.tr("Username:"))
-        self.username_input = QLineEdit()
-        self.username_input.setPlaceholderText(self.tr("Username..."))
+        instructions = QLabel(
+            self.tr(
+                """In the browser that opens, login to your Just Eat account.
 
-        self.password_label = QLabel(self.tr("Password:"))
-        self.password_input = QLineEdit()
-        self.password_input.setPlaceholderText(self.tr("Password..."))
-        self.password_input.setEchoMode(QLineEdit.EchoMode.Password)
+It will automatically close once login is completed.
 
-        self.reset_password_button = QLabel(self.tr("Reset Password..."))
-        font = QFont()
-        font.setUnderline(True)
-        self.reset_password_button.setFont(font)
-        self.reset_password_button.setAlignment(Qt.AlignmentFlag.AlignLeft)
-        self.reset_password_button.setStyleSheet("color: #606060;")
-        self.reset_password_button.setCursor(Qt.CursorShape.PointingHandCursor)
-        self.reset_password_button.mousePressEvent = self.reset_password
-
-        self.login_button = QPushButton(self.tr("Login"))
-        self.login_button.clicked.connect(self.handle_login)
+IMPORTANT - DO NOT RESIZE THE BROWSER WINDOW. DOING SO CAN CAUSE THE PROCESS TO FAIL."""
+            )
+        )
+        instructions.setWordWrap(True)
 
         self.layout = QVBoxLayout()
-        self.layout.addWidget(self.username_label)
-        self.layout.addWidget(self.username_input)
-        self.layout.addWidget(self.password_label)
-        self.layout.addWidget(self.password_input)
-        self.layout.addWidget(self.reset_password_button)
-        self.layout.addWidget(self.login_button)
+        self.layout.addWidget(instructions)
         self.setLayout(self.layout)
+
+        self.browser_thread = QThread()
+        self.browser_worker = BrowserWorker()
 
     def initializePage(self):
         QTimer.singleShot(0, self.disable_next_button)
 
-    def disable_next_button(self):
-        self.wizard().button(QWizard.WizardButton.NextButton).setEnabled(False)
-
-    def nextId(self):
-        if self.has_2fa:
-            return 5
-
-        return 6
-
-    def reset_password(self, event=None):
-        global country
-        device_id = random.choice(devices)
-
         try:
             resp = requests.get(
-                f"https://just-eat.wiilink.ca/resetdata.json?device_id={device_id}&country={country}"
-            )
-            resp.raise_for_status()
-        except HTTPError:
-            exception_traceback = traceback.format_exc()
-            print(exception_traceback)
-            QMessageBox.critical(
-                self,
-                "WiiLink Just Eat Linker - Error",
-                f"""The linker was unable to get password reset information from WiiLink servers.
-
-Received status code {resp.status_code}.
-Response: {resp.text}""",
-            )
-            return
-        except:
-            exception_traceback = traceback.format_exc()
-            print(exception_traceback)
-            QMessageBox.critical(
-                self,
-                "WiiLink Just Eat Linker - Error",
-                f"""The linker was unable to get password reset information from WiiLink servers.
-
-{exception_traceback}""",
-            )
-            return
-
-        data = resp.json()
-        payload = {
-            "EmailAddress": self.username_input.text(),
-        }
-
-        try:
-            resp = requests.post(
-                data["url"],
-                headers=data["header"],
-                data=json.dumps(payload),
-                impersonate="safari17_0",
-            )
-            resp.raise_for_status()
-        except HTTPError:
-            exception_traceback = traceback.format_exc()
-            print(exception_traceback)
-            QMessageBox.critical(
-                self,
-                "WiiLink Just Eat Linker - Error",
-                f"""The linker was unable to request the password reset.
-
-Received status code {resp.status_code}.
-Response: {resp.text}""",
-            )
-            return
-        except:
-            exception_traceback = traceback.format_exc()
-            print(exception_traceback)
-            QMessageBox.critical(
-                self,
-                "WiiLink Just Eat Linker - Error",
-                f"""The linker was unable to request the password reset.
-
-{exception_traceback}""",
-            )
-            return
-
-        QMessageBox.information(
-            self,
-            "Successfully reset password",
-            f"If there is a Just Eat account associated with <b>{self.username_input.text()}</b>, you will receive an email from Just Eat to reset your password.",
-        )
-
-    def handle_login(self):
-        global country
-        device_id = random.choice(devices)
-
-        try:
-            resp = requests.get(
-                f"https://just-eat.wiilink.ca/userdatalogin.json?device_id={device_id}&country={country}"
+                f"https://just-eat.wiilink.ca/loginurls.json?country={country}"
             )
             resp.raise_for_status()
         except HTTPError:
@@ -222,8 +120,8 @@ Response: {resp.text}""",
                 "WiiLink Just Eat Linker - Error",
                 f"""The linker was unable to get login information from WiiLink servers.
 
-Received status code {resp.status_code}.
-Response: {resp.text}""",
+        Received status code {resp.status_code}.
+        Response: {resp.text}""",
             )
             return
         except:
@@ -234,215 +132,41 @@ Response: {resp.text}""",
                 "WiiLink Just Eat Linker - Error",
                 f"""The linker was unable to get login information from WiiLink servers.
 
-{exception_traceback}""",
+        {exception_traceback}""",
             )
             return
 
-        # Complete the body based on the user's inputs.
-        data = resp.json()
-        payload = data["payload"]
+        self.browser_worker.browser_path = self.wizard().property("browser")
+        self.browser_worker.eater_url = resp.json()["eater_url"]
+        self.browser_worker.token_url = resp.json()["token_url"]
 
+        self.browser_worker.moveToThread(self.browser_thread)
+        self.browser_thread.started.connect(self.browser_worker.begin_browser)
+        self.browser_worker.token_signal.connect(self.browser_done)
+        self.browser_worker.token_signal.connect(self.browser_thread.quit)
+        self.browser_worker.token_signal.connect(self.browser_worker.deleteLater)
+        self.browser_worker.token_signal.connect(self.browser_thread.deleteLater)
+
+        self.browser_thread.start()
+
+    def browser_done(self, token: dict):
+        global country
+
+        device_id = random.choice(devices)
         acr_device = {
             "DeviceType": "Android",
             "DeviceName": device_id,
             "DeviceId": str(uuid.uuid4()),
         }
         acr = f"tenant:{country} device:{base64.b64encode(json.dumps(acr_device).encode()).decode()} deviceId:{device_id}"
-        payload["acr"] = acr
-        payload["username"] = self.username_input.text()
-        payload["password"] = self.password_input.text()
 
-        try:
-            resp = requests.post(
-                data["url"],
-                headers=data["header"],
-                data=payload,
-                impersonate="safari17_0",
-            )
-        except:
-            exception_traceback = traceback.format_exc()
-            print(exception_traceback)
-            QMessageBox.critical(
-                self,
-                "WiiLink Just Eat Linker - Error",
-                f"""The linker was unable to login to your account.
-
-{exception_traceback}""",
-            )
-            return
-
-        if resp.status_code == 400 and resp.json()["error"] == "invalid_grant":
-            QMessageBox.critical(
-                self,
-                "WiiLink Just Eat Linker - Warning",
-                "Please enter the correct credentials for your Just Eat account.",
-            )
-            return
-        elif resp.status_code == 200:
-            try:
-                resp = link_to_server(
-                    resp.json(),
-                    self.wizard().property("wii_no"),
-                    self.wizard().property("access_token"),
-                    device_id,
-                    acr,
-                )
-                resp.raise_for_status()
-            except HTTPError:
-                exception_traceback = traceback.format_exc()
-                print(exception_traceback)
-                QMessageBox.critical(
-                    self,
-                    "WiiLink Just Eat Linker - Error",
-                    f"""The linker was unable to link your Just Eat account to your WiiLink account.
-
-Received status code {resp.status_code}.
-Response: {resp.text}""",
-                )
-                return
-            except:
-                exception_traceback = traceback.format_exc()
-                print(exception_traceback)
-                QMessageBox.critical(
-                    self,
-                    "WiiLink Just Eat Linker - Error",
-                    f"""The linker was unable to link your Just Eat account to your WiiLink account.
-
-{exception_traceback}""",
-                )
-                return
-
-            self.wizard().next()
-            return
-        elif resp.status_code == 403 and resp.json()["error"] == "mfa_required":
-            data = resp.json()
-            self.has_2fa = True
-            self.wizard().setProperty("mfa_token", data["mfa_token"])
-            self.wizard().setProperty("device_id", device_id)
-            self.wizard().setProperty("payload", payload)
-            self.wizard().setProperty("acr", acr)
-            self.wizard().next()
-        else:
-            QMessageBox.critical(
-                self,
-                "WiiLink Just Eat Linker - Error",
-                f"""The linker was unable to login to your account.
-
-Received status code {resp.status_code}.
-Response: {resp.text}""",
-            )
-
-
-class JustEat2FAPage(QWizardPage):
-    def __init__(self, parent=None):
-        super().__init__(parent)
-        self.setTitle(self.tr("Just Eat Login"))
-        self.setSubTitle(self.tr("Enter the 2FA code sent to your Just Eat email"))
-
-        self.code_label = QLabel(self.tr("Code:"))
-        self.code_input = QLineEdit()
-        self.code_input.setPlaceholderText(self.tr("Code..."))
-
-        self.login_button = QPushButton(self.tr("Login"))
-        self.login_button.clicked.connect(self.handle_login)
-
-        self.layout = QVBoxLayout()
-        self.layout.addWidget(self.code_label)
-        self.layout.addWidget(self.code_input)
-        self.layout.addWidget(self.login_button)
-        self.setLayout(self.layout)
-
-    def initializePage(self):
-        QTimer.singleShot(0, self.disable_buttons)
-
-    def disable_buttons(self):
-        self.wizard().button(QWizard.WizardButton.BackButton).setEnabled(False)
-        self.wizard().button(QWizard.WizardButton.NextButton).setEnabled(False)
-
-    def handle_login(self):
-        global country
-        mfa_token = self.wizard().property("mfa_token")
-        device_id = self.wizard().property("device_id")
-        other_payload = self.wizard().property("payload")
-
-        try:
-            resp = requests.get(
-                f"https://just-eat.wiilink.ca/2fadata.json?device_id={device_id}&country={country}"
-            )
-            resp.raise_for_status()
-        except HTTPError:
-            exception_traceback = traceback.format_exc()
-            print(exception_traceback)
-            QMessageBox.critical(
-                self,
-                "WiiLink Just Eat Linker - Error",
-                f"""The linker was unable to connect to WiiLink servers.
-
-Received status code {resp.status_code}.
-Message: {resp.text}""",
-            )
-            return
-        except:
-            exception_traceback = traceback.format_exc()
-            print(exception_traceback)
-            QMessageBox.critical(
-                self,
-                "WiiLink Just Eat Linker - Error",
-                f"""The linker was unable to connect to WiiLink servers.
-
-{exception_traceback}""",
-            )
-            return
-
-        # Complete the body based on the user's inputs.
-        data = resp.json()
-        payload = data["payload"]
-        other_payload.update(payload)
-        other_payload["mfa_token"] = mfa_token
-        other_payload["otp"] = self.code_input.text()
-
-        # Post to the 2FA endpoint.
-        try:
-            resp = requests.post(
-                data["url"],
-                headers=data["header"],
-                data=other_payload,
-                impersonate="safari17_0",
-            )
-            resp.raise_for_status()
-        except HTTPError:
-            exception_traceback = traceback.format_exc()
-            print(exception_traceback)
-            QMessageBox.critical(
-                self,
-                "WiiLink Just Eat Linker - Error",
-                f"""The linker was unable to authenticate with your provided 2FA code.
-
-Received status code {resp.status_code}.
-Message: {resp.text}""",
-            )
-            return
-        except:
-            exception_traceback = traceback.format_exc()
-            print(exception_traceback)
-            QMessageBox.critical(
-                self,
-                "WiiLink Just Eat Linker - Error",
-                f"""The linker was unable to authenticate with your provided 2FA code.
-
-{exception_traceback}""",
-            )
-            return
-
-        # We now need to send the auth data to the Demae Just Eat server.
-        data = resp.json()
         try:
             resp = link_to_server(
-                data,
+                token,
                 self.wizard().property("wii_no"),
                 self.wizard().property("access_token"),
-                self.wizard().property("device_id"),
-                self.wizard().property("acr"),
+                device_id,
+                acr,
             )
             resp.raise_for_status()
         except HTTPError:
@@ -453,8 +177,8 @@ Message: {resp.text}""",
                 "WiiLink Just Eat Linker - Error",
                 f"""The linker was unable to link your Just Eat account to your WiiLink account.
 
-Received status code {resp.status_code}.
-Message: {resp.text}""",
+            Received status code {resp.status_code}.
+            Response: {resp.text}""",
             )
             return
         except:
@@ -465,8 +189,60 @@ Message: {resp.text}""",
                 "WiiLink Just Eat Linker - Error",
                 f"""The linker was unable to link your Just Eat account to your WiiLink account.
 
-{exception_traceback}""",
+            {exception_traceback}""",
             )
             return
 
-        self.wizard().next()
+        self.login_complete = True
+        self.completeChanged.emit()
+        QTimer.singleShot(0, self.wizard().next)
+
+    def disable_next_button(self):
+        self.wizard().button(QWizard.WizardButton.NextButton).setEnabled(False)
+
+    def isComplete(self):
+        return self.login_complete
+
+    def nextId(self):
+        return 5
+
+
+class BrowserWorker(QObject):
+    page: uc.Tab
+    browser: uc.Browser
+    token_json: dict
+    eater_url: str
+    token_url: str
+    browser_path: str = None
+    token_got = asyncio.Event()
+
+    token_signal = Signal(dict)
+
+    def begin_browser(self):
+        uc.loop().run_until_complete(self.run_browser())
+
+    async def run_browser(self):
+        self.browser = await uc.start(
+            browser_executable_path=self.browser_path,
+            # size to match phone screen, window position to put it always in the top left corner
+            browser_args=["--window-size=412,915", "--window-position=0,0"],
+        )
+        self.page = await self.browser.get("about:blank")
+        self.page.add_handler(uc.cdp.network.ResponseReceived, self.handler)
+
+        # domain from api "checkoutUrl"
+        self.page = await self.browser.get(self.eater_url)
+
+        await self.token_got.wait()
+        self.browser.stop()
+        self.token_signal.emit(self.token_json)
+
+    async def handler(self, evt: uc.cdp.network.ResponseReceived):
+        if evt.response.encoded_data_length > 0:
+            # domain from api "authenticationApiUrl"
+            if evt.response.url == self.token_url:
+                body, is_base64 = await self.page.send(
+                    uc.cdp.network.get_response_body(evt.request_id)
+                )
+                self.token_json = json.loads(body)
+                self.token_got.set()

--- a/just_eat.py
+++ b/just_eat.py
@@ -1,6 +1,11 @@
 import asyncio
 import traceback
 import uuid
+import random
+import base64
+import json
+import time
+import requests
 import nodriver as uc
 
 from PySide6.QtWidgets import (
@@ -12,14 +17,8 @@ from PySide6.QtWidgets import (
     QMessageBox,
 )
 from PySide6.QtCore import QTimer, QObject, Signal, QThread
-from curl_cffi import requests
-from curl_cffi.requests.exceptions import HTTPError
+from requests.exceptions import HTTPError
 from constants import devices, linker_version
-
-import random
-import base64
-import json
-import time
 
 country = ""
 

--- a/oauth.py
+++ b/oauth.py
@@ -1,9 +1,7 @@
 import time
 import sys
 import traceback
-
-from curl_cffi import requests
-from curl_cffi.requests.exceptions import HTTPError
+import requests
 
 from constants import linker_version
 from PySide6.QtWidgets import (
@@ -15,6 +13,7 @@ from PySide6.QtWidgets import (
     QMessageBox,
 )
 from PySide6.QtCore import QThread, QObject, Signal, QTimer, Qt
+from requests.exceptions import HTTPError
 
 access_token = ""
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
+requests
 PySide6~=6.9.0
 black
 nuitka
 imageio
-curl_cffi
+nodriver


### PR DESCRIPTION
Now requires a Chromium browser, unfortunate but the best solution. Not fully tested as the server is currently returning HTTP 500 on the `/link` route, needs fixed separately.