### PR TITLE
fix: Fix-up encoding for nodriver's network.py

### DIFF
--- a/.github/workflows/push_build.yml
+++ b/.github/workflows/push_build.yml
@@ -28,6 +28,11 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
+    - name: Fix-up encoding for nodriver network.py
+      run: |
+        export NODRIVER_LOC="$(python -c "import site; print(site.getsitepackages()[-1] + '/nodriver/cdp/network.py')")"
+        iconv -f ISO-8859-15 -t UTF-8 "$NODRIVER_LOC" > /tmp/network-fix.py
+        mv /tmp/network-fix.py "$NODRIVER_LOC"
     - name: Build Package
       run: make all
     - name: Prepare Package for Upload
@@ -59,6 +64,11 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
+    - name: Fix-up encoding for nodriver network.py
+      run: |
+        export NODRIVER_LOC="$(python -c "import site; print(site.getsitepackages()[-1] + '/nodriver/cdp/network.py')")"
+        iconv -f ISO-8859-15 -t UTF-8 "$NODRIVER_LOC" > /tmp/network-fix.py
+        mv /tmp/network-fix.py "$NODRIVER_LOC"
     - name: Build Package
       run: make all
     - name: Prepare Package for Upload
@@ -86,6 +96,11 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+      - name: Fix-up encoding for nodriver network.py
+        run: |
+          export NODRIVER_LOC="$(python -c "import site; print(site.getsitepackages()[-1] + '/nodriver/cdp/network.py')")"
+          iconv -f ISO-8859-15 -t UTF-8 "$NODRIVER_LOC" > /tmp/network-fix.py
+          mv /tmp/network-fix.py "$NODRIVER_LOC"
       - name: Build Package
         run: ARCH_FLAGS=--macos-target-arch=x86_64 make all
       - name: Prepare Package for Upload
@@ -113,6 +128,11 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+      - name: Fix-up encoding for nodriver network.py
+        run: |
+          export NODRIVER_LOC="$(python -c "import site; print(site.getsitepackages()[-1] + '/nodriver/cdp/network.py')")"
+          iconv -f ISO-8859-15 -t UTF-8 "$NODRIVER_LOC" > /tmp/network-fix.py
+          mv /tmp/network-fix.py "$NODRIVER_LOC"
       - name: Build Package
         run: ARCH_FLAGS=--macos-target-arch=arm64 make all
       - name: Prepare Package for Upload

--- a/build.ps1
+++ b/build.ps1
@@ -5,6 +5,12 @@ param(
 )
 
 $buildProject = {
+    Write-Host "Fixing nodriver network.py encoding..."
+    $NODRIVER_LOC = Invoke-Expression "python -c `"import site; print(site.getsitepackages()[-1] + '/nodriver/cdp/network.py')`""
+    Get-Content "$NODRIVER_LOC" | Set-Content -Encoding utf8 ".\network-fix.py"
+    Copy-Item -Path ".\network-fix.py" -Destination "$NODRIVER_LOC" -Force
+    Remove-Item -Path ".\network-fix.py"
+    
     Write-Host "Building Just Eat Linker..."
     pyside6-project build pyproject.toml
 


### PR DESCRIPTION
This PR fixes the https://github.com/ultrafunkamsterdam/nodriver/issues/35 issue by converting the file encoding of `nodriver`'s `network.py` to UTF-8 prior to building.

Kind of a hack, but there's not really any other way to fix that right now besides not using nodriver or making a fixed fork of it.